### PR TITLE
Implement asynchronous search with spinner

### DIFF
--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -11,13 +11,20 @@
       translation="[100,10]"
       width="600"
       height="40"
-      hintText="Search..."/>
+      hintText="Search…"/>
     <Button
       id="SearchButton"
       translation="[720,10]"
       width="120"
       height="40"
       text="Search"/>
+    <ActivityIndicator
+      id="Spinner"
+      translation="[860,10]"
+      width="40"
+      height="40"
+      visible="false"/>
+    <SearchTask id="SearchTaskNode" />
 
     <Poster
       id="Poster"

--- a/components/SearchTask.brs
+++ b/components/SearchTask.brs
@@ -1,0 +1,17 @@
+sub init()
+    m.top.functionName = "run"
+end sub
+
+function run() as void
+    query = m.top.query
+    if query = invalid or Len(query) = 0 return
+    base = m.top.baseUrl
+    transfer = CreateObject("roUrlTransfer")
+    encoded = transfer.Escape(query)
+    url = base + "/index.php?menu=search&query=" + encoded
+    transfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
+    transfer.AddHeader("User-Agent", "Mozilla/5.0")
+    transfer.SetUrl(url)
+    html = transfer.GetToString()
+    m.top.message = html
+end function

--- a/components/SearchTask.xml
+++ b/components/SearchTask.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<component name="SearchTask" extends="Task">
+  <interface>
+    <field id="query" type="string" />
+    <field id="baseUrl" type="string" />
+  </interface>
+  <script type="text/brightscript" uri="pkg:/components/SearchTask.brs" />
+</component>


### PR DESCRIPTION
## Summary
- show ActivityIndicator while search runs
- create `SearchTask` component for async search
- start the task from `onSearchPress`
- update UI focus behavior when list hidden
- keep search box hint text updated

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686da2b0c0e48330aff0d1b39a4f5c48