### PR TITLE
Move search parsing logic

### DIFF
--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -113,29 +113,16 @@ end function
 'load video list from web page'
 
 sub LoadVideoList(html as String)
-    figureRegex = CreateObject("roRegex", "<figure class=\"figured\">(.*?)</figure>", "ims")
-    hrefRegex = CreateObject("roRegex", "href=\"([^\"]+)\"", "ims")
-    imgRegex = CreateObject("roRegex", "(?:data-src|src)=\"([^\"]+)\"", "ims")
-    titleRegex = CreateObject("roRegex", "<div class=\"title detz\">([^<]+)</div>", "ims")
     listContent = CreateObject("roSGNode", "ContentNode")
-
-    figures = figureRegex.MatchAll(html)
-    for each item in figures
-        block = item[1]
-        hrefMatch = hrefRegex.Match(block)
-        imgMatch = imgRegex.Match(block)
-        titleMatch = titleRegex.Match(block)
-        if hrefMatch.Count() > 0 and imgMatch.Count() > 0 and titleMatch.Count() > 0
-            node = listContent.CreateChild("ContentNode")
-            path = hrefMatch[1]
-            if Left(path,1) = "/" then path = m.baseUrl + path
-            node.title = titleMatch[1]
-            node.url = path
-            node.description = "mp4"
-            node.hdposterurl = imgMatch[1]
-            node.AddField("hosts", "string", true)
-            node.hosts = [ path ]
-        end if
+    results = ParseSearchResults(html, m.baseUrl)
+    for each item in results
+        node = listContent.CreateChild("ContentNode")
+        node.title = item.title
+        node.url = item.pageUrl
+        node.description = "mp4"
+        node.hdposterurl = item.imgUrl
+        node.AddField("hosts", "string", true)
+        node.hosts = [ item.pageUrl ]
     end for
 
     m.list.content = listContent

--- a/source/HtmlUtils.brs
+++ b/source/HtmlUtils.brs
@@ -1,0 +1,37 @@
+'Utility functions for HTML parsing
+'
+'ParseSearchResults returns an array of objects with { title, imgUrl, pageUrl }
+'Any malformed figure blocks will be logged via print statements
+
+function ParseSearchResults(html as String, baseUrl as String) as Object
+    results = []
+    if html = invalid return results
+
+    figureRegex = CreateObject("roRegex", "<figure class=\"figured\">(.*?)</figure>", "ims")
+    hrefRegex = CreateObject("roRegex", "href=\"([^\"]+)\"", "ims")
+    imgRegex = CreateObject("roRegex", "(?:data-src|src)=\"([^\"]+)\"", "ims")
+    titleRegex = CreateObject("roRegex", "<div class=\"title detz\">([^<]+)</div>", "ims")
+
+    figures = figureRegex.MatchAll(html)
+    for each item in figures
+        block = item[1]
+        hrefMatch = hrefRegex.Match(block)
+        imgMatch = imgRegex.Match(block)
+        titleMatch = titleRegex.Match(block)
+        if hrefMatch.Count() = 0 or imgMatch.Count() = 0 or titleMatch.Count() = 0
+            print "Malformed figure block:" + Chr(10) + block
+        else
+            path = hrefMatch[1]
+            if Left(path,1) = "/" then path = baseUrl + path
+            result = {
+                title: titleMatch[1],
+                imgUrl: imgMatch[1],
+                pageUrl: path
+            }
+            results.Push(result)
+        end if
+    end for
+
+    return results
+end function
+


### PR DESCRIPTION
## Summary
- factor HTML parsing out of `LoadVideoList`
- add `HtmlUtils.brs` with `ParseSearchResults`
- use new helper when building list content

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686da43c1d048330b7283230d8a7cd59