### PR TITLE
Implement host fallback and playback handling

### DIFF
--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -33,6 +33,18 @@
       height="513"
       visible="false"/>
 
+    <Label
+      id="HostMessage"
+      translation="[100,600]"
+      width="600"
+      height="40"
+      visible="false"/>
+
+    <Timer
+      id="HostMessageTimer"
+      repeat="false"
+      duration="2"/>
+
     <!-- video -->
     <Video
       id="Video"


### PR DESCRIPTION
## Summary
- flag episode headers for easier skip logic
- store hosts and reset index when starting playback
- automatically switch video host on errors
- surface host changes with an on-screen label

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686da55277ac8330971098f8b432d0b5