### PR TITLE
Add logging utility and integrate across playback

### DIFF
--- a/components/EpisodeTask.brs
+++ b/components/EpisodeTask.brs
@@ -4,11 +4,20 @@ end sub
 
 function run() as void
     url = m.top.url
-    if url = invalid or Len(url) = 0 return
+    if url = invalid or Len(url) = 0 then
+        Log("EpisodeTask: no URL specified")
+        return
+    end if
+    Log("EpisodeTask requesting " + url)
     xfer = CreateObject("roUrlTransfer")
     xfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     xfer.AddHeader("User-Agent", "Mozilla/5.0")
     xfer.SetUrl(url)
     html = xfer.GetToString()
+    if html = invalid then
+        Log("EpisodeTask failed to load " + url)
+    else
+        Log("EpisodeTask received response")
+    end if
     m.top.message = html
 end function

--- a/components/HostTask.brs
+++ b/components/HostTask.brs
@@ -4,11 +4,20 @@ end sub
 
 function run() as void
     url = m.top.url
-    if url = invalid or Len(url) = 0 return
+    if url = invalid or Len(url) = 0 then
+        Log("HostTask: no URL specified")
+        return
+    end if
+    Log("HostTask requesting " + url)
     xfer = CreateObject("roUrlTransfer")
     xfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     xfer.AddHeader("User-Agent", "Mozilla/5.0")
     xfer.SetUrl(url)
     html = xfer.GetToString()
+    if html = invalid then
+        Log("HostTask failed to load " + url)
+    else
+        Log("HostTask received response")
+    end if
     m.top.message = html
 end function

--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -163,6 +163,7 @@ sub onSearchResults()
     if html <> invalid and Len(html) > 0
         LoadVideoList(html)
     else
+        Log("SearchTask returned no results")
         empty = CreateObject("roSGNode", "ContentNode")
         n = empty.CreateChild("ContentNode")
         n.title = "No matches"
@@ -188,6 +189,7 @@ sub onEpisodeResults()
             return
         end if
     else
+        Log("EpisodeTask returned no data")
         ShowHostMessage("Failed to load episodes")
     end if
     if selectedContent <> invalid
@@ -209,9 +211,11 @@ sub onHostResults()
             content.url = hosts[0]
             StartVideo(content)
         else
+            Log("HostTask returned no hosts")
             ShowHostMessage("No hosts found")
         end if
     else
+        Log("HostTask failed to load hosts")
         ShowHostMessage("Failed to load hosts")
     end if
 end sub
@@ -223,6 +227,7 @@ sub SwitchHost()
         m.currentHostIndex = (m.currentHostIndex + 1) mod hosts.Count()
         content.url = hosts[m.currentHostIndex]
         content.streamformat = DetermineFormat(content.url)
+        Log("Switching host to " + content.url)
         StartVideo(content, false)
         ShowHostMessage("Switching host " + Str(m.currentHostIndex + 1) + " of " + Str(hosts.Count()))
     end if
@@ -361,6 +366,7 @@ sub StartVideo(content as Object, resetIndex = true as Boolean)
     if resetIndex
         m.currentHostIndex = 0
     end if
+    Log("Starting playback: " + content.url)
     if content.hosts <> invalid
         m.player.content = content
         m.player.content.hosts = content.hosts
@@ -384,6 +390,7 @@ sub ResumeVideo()
 end sub
 
 sub StopVideo()
+    Log("Stopping playback")
     m.player.control = "stop"
     m.player.visible = false
     UpdateStatusOverlay()

--- a/components/SearchTask.brs
+++ b/components/SearchTask.brs
@@ -4,7 +4,10 @@ end sub
 
 function run() as void
     query = m.top.query
-    if query = invalid or Len(query) = 0 return
+    if query = invalid or Len(query) = 0 then
+        Log("SearchTask: empty query")
+        return
+    end if
     base = m.top.baseUrl
     transfer = CreateObject("roUrlTransfer")
     encoded = transfer.Escape(query)
@@ -12,6 +15,12 @@ function run() as void
     transfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     transfer.AddHeader("User-Agent", "Mozilla/5.0")
     transfer.SetUrl(url)
+    Log("SearchTask requesting " + url)
     html = transfer.GetToString()
+    if html = invalid then
+        Log("SearchTask failed to load " + url)
+    else
+        Log("SearchTask received response")
+    end if
     m.top.message = html
 end function

--- a/source/Logger.brs
+++ b/source/Logger.brs
@@ -1,0 +1,4 @@
+function Log(msg as String) as void
+    if msg = invalid then msg = "invalid"
+    print "[LOG] " + msg
+end function


### PR DESCRIPTION
## Summary
- add a simple `Log` helper
- log network calls in the search, episode, and host tasks
- log playback start/stop and host switching
- log task errors for easier debugging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686da96da150833080d5a4ddf1fd283b