### PR TITLE
Add advanced host controls and caching

### DIFF
--- a/components/EpisodeTask.brs
+++ b/components/EpisodeTask.brs
@@ -4,11 +4,29 @@ end sub
 
 function run() as void
     url = m.top.url
-    if url = invalid or Len(url) = 0 return
+    if url = invalid or Len(url) = 0 then
+        LogError("EpisodeTask: no URL specified")
+        return
+    end if
+
+    cached = CacheGet(url)
+    if cached <> invalid then
+        Log("EpisodeTask cache hit " + url)
+        m.top.message = cached
+        return
+    end if
+
+    Log("EpisodeTask requesting " + url)
     xfer = CreateObject("roUrlTransfer")
     xfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     xfer.AddHeader("User-Agent", "Mozilla/5.0")
     xfer.SetUrl(url)
     html = xfer.GetToString()
+    if html = invalid then
+        LogError("EpisodeTask failed to load " + url)
+    else
+        Log("EpisodeTask received response")
+        CacheSet(url, html)
+    end if
     m.top.message = html
 end function

--- a/components/HostTask.brs
+++ b/components/HostTask.brs
@@ -4,11 +4,29 @@ end sub
 
 function run() as void
     url = m.top.url
-    if url = invalid or Len(url) = 0 return
+    if url = invalid or Len(url) = 0 then
+        LogError("HostTask: no URL specified")
+        return
+    end if
+
+    cached = CacheGet(url)
+    if cached <> invalid then
+        Log("HostTask cache hit " + url)
+        m.top.message = cached
+        return
+    end if
+
+    Log("HostTask requesting " + url)
     xfer = CreateObject("roUrlTransfer")
     xfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     xfer.AddHeader("User-Agent", "Mozilla/5.0")
     xfer.SetUrl(url)
     html = xfer.GetToString()
+    if html = invalid then
+        LogError("HostTask failed to load " + url)
+    else
+        Log("HostTask received response")
+        CacheSet(url, html)
+    end if
     m.top.message = html
 end function

--- a/components/MainScene.brs
+++ b/components/MainScene.brs
@@ -6,6 +6,8 @@ sub init()
     m.list = m.top.FindNode("MenuList")
     m.searchBox = m.top.FindNode("SearchBox")
     m.searchButton = m.top.FindNode("SearchButton")
+    m.episodeButton = m.top.FindNode("EpisodeButton")
+    m.hostsButton = m.top.FindNode("HostsButton")
     m.poster = m.top.FindNode("Poster")
     m.hostLabel = m.top.FindNode("HostMessage")
     m.hostTimer = m.top.FindNode("HostMessageTimer")
@@ -19,6 +21,16 @@ sub init()
     m.hostTask = m.top.FindNode("HostTaskNode")
     m.hostTask.ObserveField("message", "onHostResults")
     m.searchButton.ObserveField("buttonSelected", "onSearchPress")
+    if m.episodeButton <> invalid
+        m.episodeButton.ObserveField("buttonSelected", "onEpisodeButtonPress")
+    end if
+    if m.hostsButton <> invalid
+        m.hostsButton.ObserveField("buttonSelected", "onHostsButtonPress")
+    end if
+    m.hostList = m.top.FindNode("HostList")
+    if m.hostList <> invalid
+        m.hostList.ObserveField("itemSelected", "onHostListSelect")
+    end if
     m.list.ObserveField("itemFocused", "onItemFocused")
     m.player.ObserveField("state", "onVideoStateChanged")
     m.player.visible = false
@@ -29,6 +41,7 @@ sub init()
     m.isEpisodeList = false
     m.pendingContent = invalid
     m.resumeOnMenuClose = false
+    m.prefetchTasks = []
 end sub
 
 'Handle remote control key presses'
@@ -36,7 +49,11 @@ function onKeyEvent(key as String, press as Boolean) as boolean
   print key + ":" ; press
   if press
     if key = "options"
-      SwitchHost()
+      if m.hostList.visible
+        HideHostList()
+      else
+        ShowHostList()
+      end if
       return true
     else if key = "up" and m.list.visible = true and not m.searchBox.hasFocus()
       m.searchBox.setFocus(true)
@@ -129,6 +146,7 @@ sub LoadVideoList(html as String)
 
     m.list.content = listContent
     m.originalContent = listContent
+    PrefetchEpisodes(listContent)
     m.list.visible = true
     m.list.setFocus(true)
     PauseForMenu()
@@ -138,10 +156,29 @@ end sub
 sub onSearchPress()
     query = m.searchBox.text
     if query = invalid or Len(query) = 0 return
+    ShowStatusMessage("Searching...")
     m.spinner.visible = true
     m.searchTask.query = query
     m.searchTask.control = "run"
   end sub
+
+sub onEpisodeButtonPress()
+    url = m.searchBox.text
+    if url = invalid or Len(url) = 0 return
+    ShowStatusMessage("Loading episodes...")
+    m.spinner.visible = true
+    m.episodeTask.url = url
+    m.episodeTask.control = "run"
+end sub
+
+sub onHostsButtonPress()
+    url = m.searchBox.text
+    if url = invalid or Len(url) = 0 return
+    ShowStatusMessage("Loading hosts...")
+    m.spinner.visible = true
+    m.hostTask.url = url
+    m.hostTask.control = "run"
+end sub
 
   sub SearchVideos(query as String)
     if query = invalid or Len(query) = 0 return
@@ -159,10 +196,12 @@ sub onSearchPress()
 
 sub onSearchResults()
     m.spinner.visible = false
+    ShowStatusMessage("Search complete")
     html = m.searchTask.message
     if html <> invalid and Len(html) > 0
         LoadVideoList(html)
     else
+        LogError("SearchTask returned no results")
         empty = CreateObject("roSGNode", "ContentNode")
         n = empty.CreateChild("ContentNode")
         n.title = "No matches"
@@ -176,6 +215,7 @@ end sub
 
 sub onEpisodeResults()
     m.spinner.visible = false
+    ShowStatusMessage("Episodes loaded")
     html = m.episodeTask.message
     selectedContent = m.pendingContent
     if html <> invalid and Len(html) > 0
@@ -185,9 +225,11 @@ sub onEpisodeResults()
             m.list.content = episodes
             m.isEpisodeList = true
             m.list.jumpToItem(0)
+            PrefetchHosts(episodes)
             return
         end if
     else
+        LogError("EpisodeTask returned no data")
         ShowHostMessage("Failed to load episodes")
     end if
     if selectedContent <> invalid
@@ -200,18 +242,20 @@ end sub
 
 sub onHostResults()
     m.spinner.visible = false
+    ShowStatusMessage("Hosts loaded")
     html = m.hostTask.message
     content = m.pendingContent
     if html <> invalid and Len(html) > 0
         hosts = ParseHostsFromHtml(html, content.url)
         if hosts <> invalid and hosts.Count() > 0
             content.hosts = hosts
-            content.url = hosts[0]
             StartVideo(content)
         else
+            LogError("HostTask returned no hosts")
             ShowHostMessage("No hosts found")
         end if
     else
+        LogError("HostTask failed to load hosts")
         ShowHostMessage("Failed to load hosts")
     end if
 end sub
@@ -220,12 +264,49 @@ sub SwitchHost()
     content = m.player.content
     hosts = content.hosts
     if hosts <> invalid and hosts.Count() > 1
-        m.currentHostIndex = (m.currentHostIndex + 1) mod hosts.Count()
-        content.url = hosts[m.currentHostIndex]
-        content.streamformat = DetermineFormat(content.url)
-        StartVideo(content, false)
-        ShowHostMessage("Switching host " + Str(m.currentHostIndex + 1) + " of " + Str(hosts.Count()))
+        index = (m.currentHostIndex + 1) mod hosts.Count()
+        SwitchHostTo(index)
     end if
+end sub
+
+sub SwitchHostTo(index as Integer)
+    content = m.player.content
+    hosts = content.hosts
+    if hosts <> invalid and index >= 0 and index < hosts.Count()
+        m.currentHostIndex = index
+        hostObj = hosts[index]
+        content.url = hostObj.url
+        content.streamformat = hostObj.format
+        Log("Switching host to " + content.url)
+        StartVideo(content, false)
+        ShowHostMessage("Switching host " + Str(index + 1) + " of " + Str(hosts.Count()))
+    end if
+end sub
+
+sub ShowHostList()
+    content = m.player.content
+    hosts = content.hosts
+    if hosts = invalid or hosts.Count() = 0 return
+    list = CreateObject("roSGNode", "ContentNode")
+    idx = 0
+    for each h in hosts
+        node = list.CreateChild("ContentNode")
+        node.title = "Host " + Str(idx + 1) + " (" + h.format + ")"
+        idx = idx + 1
+    end for
+    m.hostList.content = list
+    m.hostList.visible = true
+    m.hostList.setFocus(true)
+end sub
+
+sub HideHostList()
+    m.hostList.visible = false
+end sub
+
+sub onHostListSelect()
+    idx = m.hostList.itemSelected
+    HideHostList()
+    SwitchHostTo(idx)
 end sub
 
 sub ShowHostMessage(msg as String)
@@ -265,6 +346,13 @@ sub UpdateStatusOverlay()
     m.statusLabel.visible = true
 end sub
 
+sub ShowStatusMessage(msg as String)
+    if m.statusLabel <> invalid
+        m.statusLabel.text = msg
+        m.statusLabel.visible = true
+    end if
+end sub
+
 sub onVideoStateChanged()
     if m.player.state = "error" then
         SwitchHost()
@@ -298,7 +386,7 @@ function GetHostsForVideo(pageUrl as String) as object
             hosts.Push(link)
         end for
         if hosts.Count() = 0
-            hostRegex = CreateObject("roRegex", "https?://[^\"']+(mp4|m3u8)", "ims")
+            hostRegex = CreateObject("roRegex", "https?://[^\"']+(mp4|m3u8|mpd)", "ims")
             matches = hostRegex.MatchAll(html)
             for each m in matches
                 hosts.Push(m[0])
@@ -319,18 +407,46 @@ function ParseHostsFromHtml(html as String, pageUrl as String) as object
         for each m in matches
             link = m[1]
             if Left(link,1) = "/" then link = m.baseUrl + link
-            hosts.Push(link)
+            host = { url: link, format: DetermineFormat(link) }
+            hosts.Push(host)
         end for
         if hosts.Count() = 0
-            hostRegex = CreateObject("roRegex", "https?://[^\"']+(mp4|m3u8)", "ims")
+            iframeRegex = CreateObject("roRegex", "<iframe[^>]+src=\"([^\"]+)\"", "ims")
+            matches = iframeRegex.MatchAll(html)
+            for each m in matches
+                link = m[1]
+                if Left(link,1) = "/" then link = m.baseUrl + link
+                host = { url: link, format: DetermineFormat(link) }
+                hosts.Push(host)
+            end for
+        end if
+        if hosts.Count() = 0
+            sourceRegex = CreateObject("roRegex", "<source[^>]+src=\"([^\"]+)\"", "ims")
+            matches = sourceRegex.MatchAll(html)
+            for each m in matches
+                host = { url: m[1], format: DetermineFormat(m[1]) }
+                hosts.Push(host)
+            end for
+        end if
+        if hosts.Count() = 0
+            urlVarRegex = CreateObject("roRegex", "['\"](https?://[^'\"]+(mp4|m3u8))['\"]", "ims")
+            matches = urlVarRegex.MatchAll(html)
+            for each m in matches
+                host = { url: m[1], format: DetermineFormat(m[1]) }
+                hosts.Push(host)
+            end for
+        end if
+        if hosts.Count() = 0
+            hostRegex = CreateObject("roRegex", "https?://[^\"']+(mp4|m3u8|mpd)", "ims")
             matches = hostRegex.MatchAll(html)
             for each m in matches
-                hosts.Push(m[0])
+                host = { url: m[0], format: DetermineFormat(m[0]) }
+                hosts.Push(host)
             end for
         end if
     end if
     if hosts.Count() = 0
-        hosts.Push(pageUrl)
+        hosts.Push({ url: pageUrl, format: DetermineFormat(pageUrl) })
     end if
     return hosts
 end function
@@ -358,16 +474,21 @@ end function
 
 'Playback helper functions
 sub StartVideo(content as Object, resetIndex = true as Boolean)
-    if resetIndex
+    if resetIndex then
         m.currentHostIndex = 0
     end if
-    if content.hosts <> invalid
-        m.player.content = content
-        m.player.content.hosts = content.hosts
+    if content.hosts <> invalid and content.hosts.Count() > 0 then
+        hostObj = content.hosts[m.currentHostIndex]
+        content.url = hostObj.url
+        content.streamformat = hostObj.format
     else
-        m.player.content = content
+        content.streamformat = DetermineFormat(content.url)
     end if
-    content.streamformat = DetermineFormat(content.url)
+    Log("Starting playback: " + content.url)
+    m.player.content = content
+    if content.hosts <> invalid then
+        m.player.content.hosts = content.hosts
+    end if
     m.player.visible = true
     m.player.control = "play"
     UpdateStatusOverlay()
@@ -384,6 +505,7 @@ sub ResumeVideo()
 end sub
 
 sub StopVideo()
+    Log("Stopping playback")
     m.player.control = "stop"
     m.player.visible = false
     UpdateStatusOverlay()
@@ -410,6 +532,37 @@ sub ResumeFromMenu()
         ResumeVideo()
     end if
     m.resumeOnMenuClose = false
+end sub
+
+sub PrefetchEpisodes(listContent as Object)
+    limit = listContent.GetChildCount()
+    if limit > 3 then limit = 3
+    for i = 0 to limit - 1
+        item = listContent.GetChild(i)
+        if item.url <> invalid and CacheGet(item.url) = invalid
+            t = CreateObject("roSGNode", "EpisodeTask")
+            t.url = item.url
+            m.prefetchTasks.Push(t)
+            t.control = "run"
+        end if
+    end for
+end sub
+
+sub PrefetchHosts(listContent as Object)
+    limit = listContent.GetChildCount()
+    if limit > 3 then limit = 3
+    for i = 0 to limit - 1
+        item = listContent.GetChild(i)
+        if item.isHeader = true then
+            next
+        end if
+        if item.url <> invalid and CacheGet(item.url) = invalid
+            t = CreateObject("roSGNode", "HostTask")
+            t.url = item.url
+            m.prefetchTasks.Push(t)
+            t.control = "run"
+        end if
+    end for
 end sub
 
 'Parse episode links from a watch page'

--- a/components/MainScene.xml
+++ b/components/MainScene.xml
@@ -22,6 +22,22 @@
       text="Search"
       focusedTextColor="0xFFFFFFFF"
       textColor="0x888888"/>
+    <Button
+      id="EpisodeButton"
+      translation="[720,60]"
+      width="120"
+      height="40"
+      text="Load Episodes"
+      focusedTextColor="0xFFFFFFFF"
+      textColor="0x888888"/>
+    <Button
+      id="HostsButton"
+      translation="[860,60]"
+      width="120"
+      height="40"
+      text="Load Hosts"
+      focusedTextColor="0xFFFFFFFF"
+      textColor="0x888888"/>
     <ActivityIndicator
       id="Spinner"
       translation="[860,10]"
@@ -75,6 +91,13 @@
       visible="false"
       focusBitmapUri="pkg:/images/mm-icon-side-hd.jpg">
       <ContentNode id="menucontent" role="content" />
+    </LabelList>
+    <LabelList
+      id="HostList"
+      translation="[100,300]"
+      itemSize="[400,40]"
+      visible="false">
+      <ContentNode id="hostcontent" role="content" />
     </LabelList>
   </children>
 

--- a/components/SearchTask.brs
+++ b/components/SearchTask.brs
@@ -4,14 +4,32 @@ end sub
 
 function run() as void
     query = m.top.query
-    if query = invalid or Len(query) = 0 return
+    if query = invalid or Len(query) = 0 then
+        LogError("SearchTask: empty query")
+        return
+    end if
     base = m.top.baseUrl
     transfer = CreateObject("roUrlTransfer")
     encoded = transfer.Escape(query)
     url = base + "/index.php?menu=search&query=" + encoded
+
+    cached = CacheGet(url)
+    if cached <> invalid then
+        Log("SearchTask cache hit " + url)
+        m.top.message = cached
+        return
+    end if
+
     transfer.SetCertificatesFile("common:/certs/ca-bundle.crt")
     transfer.AddHeader("User-Agent", "Mozilla/5.0")
     transfer.SetUrl(url)
+    Log("SearchTask requesting " + url)
     html = transfer.GetToString()
+    if html = invalid then
+        LogError("SearchTask failed to load " + url)
+    else
+        Log("SearchTask received response")
+        CacheSet(url, html)
+    end if
     m.top.message = html
 end function

--- a/source/HtmlUtils.brs
+++ b/source/HtmlUtils.brs
@@ -7,10 +7,10 @@ function ParseSearchResults(html as String, baseUrl as String) as Object
     results = []
     if html = invalid return results
 
-    figureRegex = CreateObject("roRegex", "<figure class=\"figured\">(.*?)</figure>", "ims")
-    hrefRegex = CreateObject("roRegex", "href=\"([^\"]+)\"", "ims")
-    imgRegex = CreateObject("roRegex", "(?:data-src|src)=\"([^\"]+)\"", "ims")
-    titleRegex = CreateObject("roRegex", "<div class=\"title detz\">([^<]+)</div>", "ims")
+    figureRegex = CreateObject("roRegex", "<figure[^>]*class\\s*=\\s*\"figured\"[^>]*>(.*?)</figure>", "ims")
+    hrefRegex = CreateObject("roRegex", "<a[^>]+href=\"([^\"]+)\"", "ims")
+    imgRegex = CreateObject("roRegex", "<img[^>]+(?:data-src|src)=\"([^\"]+)\"", "ims")
+    titleRegex = CreateObject("roRegex", "<(?:div|figcaption)[^>]*class=\"title[^"]*\"[^>]*>([^<]+)<", "ims")
 
     figures = figureRegex.MatchAll(html)
     for each item in figures

--- a/source/Logger.brs
+++ b/source/Logger.brs
@@ -1,0 +1,46 @@
+function Log(msg as String) as void
+    if msg = invalid then msg = "invalid"
+    print "[LOG] " + msg
+end function
+
+'Print and store an error message so it can be reviewed later'
+function LogError(msg as String) as void
+    if msg = invalid then msg = "invalid"
+    g = GetGlobalAA()
+    if g.DoesExist("errorLogs") = false then
+        g.errorLogs = []
+    end if
+    g.errorLogs.Push(msg)
+    if g.errorLogs.Count() > 50 then
+        g.errorLogs.Shift()
+    end if
+    print "[ERR] " + msg
+end function
+
+'Return stored error messages'
+function GetErrorLogs() as object
+    g = GetGlobalAA()
+    if g.DoesExist("errorLogs") then
+        return g.errorLogs
+    else
+        return []
+    end if
+end function
+
+'Cache helpers for HTTP requests'
+function CacheSet(url as String, data as dynamic) as void
+    g = GetGlobalAA()
+    if g.DoesExist("httpCache") = false then
+        g.httpCache = {}
+    end if
+    g.httpCache[url] = data
+end function
+
+function CacheGet(url as String) as dynamic
+    g = GetGlobalAA()
+    if g.DoesExist("httpCache") and g.httpCache.DoesExist(url) then
+        return g.httpCache[url]
+    else
+        return invalid
+    end if
+end function


### PR DESCRIPTION
## Summary
- centralize logging with error storage and http caching
- cache network responses in tasks
- enhance host parsing with additional patterns
- allow host selection from a new host list overlay
- add buttons to run EpisodeTask and HostTask directly
- refine regex and prefetch hosts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686da96da150833080d5a4ddf1fd283b